### PR TITLE
Format hlint messages with newlines instead of `▫︎` 

### DIFF
--- a/src/hlint/index.ts
+++ b/src/hlint/index.ts
@@ -82,10 +82,10 @@ const HLINT_SEV_TO_GITHUB_SEV: Record<Severity, GitHubSeverity> = {
 };
 
 /**
- * Use JSON escaping to turn messages with newlines and such into a single line.
+ * Use JSON escaping to turn convert literal newlines to Github Action-supported newlines.
  */
 function escapeString(str: string, quote: boolean): string {
-  const jsonEscaped = JSON.stringify(str).replace(/\n/g, ' ');
+  const jsonEscaped = JSON.stringify(str).replace(/\n/g, '%0A');
   // Possibly drop the surrounding quotes
   return quote ? jsonEscaped : jsonEscaped.slice(1, jsonEscaped.length - 1);
 }
@@ -94,7 +94,7 @@ function escapeString(str: string, quote: boolean): string {
  * Combine the non-"poblemMatcher" fields of an "idea" into
  * a single line as a human-readable message.
  *
- * Fields are visually separated by a box character (' ▫︎ ').
+ * Fields are visually separated by newlines.
  */
 function getNiceMessage(idea: Idea): string {
   const prefixParts = [];
@@ -119,7 +119,7 @@ function getNiceMessage(idea: Idea): string {
   if (idea.note && idea.note.length) {
     messageParts.push(`Note: ${idea.note.map(n => escapeString(n, false)).join(' ')}`);
   }
-  const message = messageParts.join(' ▫︎ ');
+  const message = messageParts.join('%0A');
   return [prefix, message].filter(Boolean).join(': ');
 }
 


### PR DESCRIPTION
Recreated from haskell/actions#265

I find the long lines with `▫︎` quite difficult to read. This is an untested attempt to improve formatting.