### PR TITLE
Bump to `hlint-setup` 2.4.10.

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -31,7 +31,7 @@ jobs:
     - run: yarn test
 
     - name: Set up HLint
-      uses: haskell-actions/hlint-setup@0b0024319753ba0c8b2fa21b7018ed252aed8181 # v2.4.9
+      uses: haskell-actions/hlint-setup@fe9cd1cd1af94a23900c06738e73f6ddb092966a # v2.4.10
 
     - run: hlint --version
 


### PR DESCRIPTION
This is to prepare for 2.4.10 release.